### PR TITLE
Fix [amoc, users, size] metric

### DIFF
--- a/src/amoc_arsenal.app.src
+++ b/src/amoc_arsenal.app.src
@@ -26,7 +26,7 @@
                 ]},
                 []
             },
-            {[amoc, users], {function, ets, info, [amoc_users], proplist, [size]}, []}
+            {[amoc, users], {function, amoc_metrics, user_size, [], proplist, [size]}, []}
         ]}
     ]},
     {modules, []},

--- a/src/amoc_metrics.erl
+++ b/src/amoc_metrics.erl
@@ -1,6 +1,6 @@
 -module(amoc_metrics).
 
--export([start/0, init/2]).
+-export([start/0, init/2, user_size/0]).
 -export([update_time/2, update_counter/2, update_counter/1, update_gauge/2]).
 
 -include_lib("kernel/include/logger.hrl").
@@ -26,6 +26,9 @@ init(Type, Name) ->
     ExType = exometer_metric_type(Type),
     create_metric_and_maybe_subscribe(ExName, ExType).
 
+-spec user_size() -> [{size, non_neg_integer()}].
+user_size() ->
+    [{size, amoc_users_sup:count_no_of_users()}].
 
 -spec update_time(name(), integer()) -> ok.
 update_time(Name, Value) ->


### PR DESCRIPTION
It was reading an ets table that is in fact an implementation detail.
Now it uses the correctly exposed callback to read.

```
$ rebar3 shell
===> Verifying dependencies...
===> Analyzing applications...
===> Compiling amoc_arsenal
Erlang/OTP 27 [erts-15.0.1] [source] [64-bit] [smp:12:12] [ds:12:12:10] [async-threads:1] [jit]

Eshell V15.0.1 (press Ctrl+G to abort, type help(). for help)
=WARNING REPORT==== 29-Aug-2024::17:38:43.547597 ===
Reporter=exometer_report_graphite not_enabled
=WARNING REPORT==== 29-Aug-2024::17:38:43.547645 ===
Reporter=exometer_report_graphite not_enabled
=WARNING REPORT==== 29-Aug-2024::17:38:43.547662 ===
Reporter=exometer_report_graphite not_enabled
===> Booted compiler
===> Booted telemetry
===> Booted amoc
===> Booted exometer_core
===> Booted exometer_report_graphite
===> Booted jsx
===> Booted rfc3339
===> Booted jesse
===> Booted cowlib
===> Booted ranch
===> Booted cowboy
===> Booted amoc_rest
===> Booted syntax_tools
===> Booted edoc
===> Booted xmerl
===> Booted docsh
===> Booted amoc_arsenal
===> Booted runtime_tools
1> exometer:get_value([amoc, users]).
{ok,[{size,0}]}
```