### PR TITLE
Test amoc_metrics 

### DIFF
--- a/ci/dummy_scenario.erl
+++ b/ci/dummy_scenario.erl
@@ -43,6 +43,8 @@ test_verification_function(_)    -> {true, new_value}.
 
 -spec init() -> ok.
 init() ->
+    ok = amoc_metrics:init(counters, dummy_scenario_metric),
+    ok = amoc_metrics:init(times, dummy_scenario_metric),
     %% amoc follows a couple of rules during the scenario initialisation:
     %%  - if any parameter verification fails, amoc will not start
     %%    the scenario and the init/0 function is not triggered.
@@ -73,6 +75,8 @@ init() ->
 
 -spec start(amoc_scenario:user_id()) -> any().
 start(_Id) ->
+    ok = amoc_metrics:update_counter(dummy_scenario_metric, 1),
+    ok = amoc_metrics:update_time(dummy_scenario_metric, rand:uniform(1 bsl 16)),
     %%sleep 15 minutes
     timer:sleep(timer:minutes(15)),
     amoc_user:stop().

--- a/ci/test_run_scenario.sh
+++ b/ci/test_run_scenario.sh
@@ -28,3 +28,4 @@ worker_status=( '"amoc_status":"up"'
                 '"interarrival":"50"' )
 get_status amoc-worker-1 | contains "${worker_status[@]}"
 get_status amoc-worker-2 | contains "${worker_status[@]}"
+retry 60 curl 'http://localhost:9090/api/v1/query?query=\{__name__="dummy_scenario_metric"\}' | contains "success"

--- a/src/amoc_metrics.erl
+++ b/src/amoc_metrics.erl
@@ -29,13 +29,13 @@ start_predefined_metrics(App) ->
 
 -spec init(type(), name()) -> ok.
 init(counters, Name) ->
-    prometheus_counter:new([{name, Name}]);
+    prometheus_counter:new([{name, Name}, {help, ""}]);
 init(gauge, Name) ->
-    prometheus_gauge:new([{name, Name}]);
+    prometheus_gauge:new([{name, Name}, {help, ""}]);
 init(summary, Name) ->
-    prometheus_summary:new([{name, Name}]);
+    prometheus_summary:new([{name, Name}, {help, ""}]);
 init(Type, Name) when histogram =:= Type; times =:= Type ->
-    prometheus_histogram:new([{name, Name}, {buckets, histogram_buckets()}]).
+    prometheus_histogram:new([{name, Name}, {buckets, histogram_buckets()}, {help, ""}]).
 
 -spec update_counter(name()) -> ok.
 update_counter(Name) ->
@@ -51,7 +51,7 @@ update_gauge(Name, Value) ->
 
 -spec update_time(name(), integer()) -> ok.
 update_time(Name, Value) ->
-    prometheus_summary:observe(Name, Value).
+    prometheus_histogram:observe(Name, Value).
 
 -spec collect_mf(prometheus_registry:registry(), prometheus_collector:collect_mf_callback()) -> ok.
 collect_mf(_Registry, Callback) ->

--- a/test/scenario_template.hrl
+++ b/test/scenario_template.hrl
@@ -12,10 +12,12 @@ some edoc
 
 -spec init() -> ok.
 init() ->
+    ok = amoc_metrics:init(counters, ", (atom_to_binary(Name, utf8))/binary, "),
     ok.
 
 -spec start(amoc_scenario:user_id()) -> any().
 start(Id) ->
+    ok = amoc_metrics:update_counter(", (atom_to_binary(Name, utf8))/binary, ", 1),
     amoc_user:stop().
 
 %% generated at", ?FILE, ":", (integer_to_binary(?LINE))/binary>>).


### PR DESCRIPTION
Prometheus would crash when creating a metric if it doesn't declare a help string.