### PR TITLE
Fix app metrics

### DIFF
--- a/src/amoc_metrics.erl
+++ b/src/amoc_metrics.erl
@@ -117,6 +117,6 @@ maybe_subscribe(ExName, Datapoints) ->
     end.
 
 maybe_init_predefined_metrics() ->
-    App = application:get_application(?MODULE),
+    {ok, App} = application:get_application(?MODULE),
     Preconfigured = application:get_env(App, predefined_metrics, []),
     [init(Type, Name) || {Type, Name} <- lists:flatten(Preconfigured)].


### PR DESCRIPTION
My initial fix to this bug was to enable an API that would allow you to choose from where to load specific metrics, that you could call manually. As it was suggested by @chrzaszcz, we could instead just define `amoc_arsenal` metrics in the app config of the application repo.