### PR TITLE
No need to fail if the metric already existed

### DIFF
--- a/ci/dummy_scenario.erl
+++ b/ci/dummy_scenario.erl
@@ -43,8 +43,8 @@ test_verification_function(_)    -> {true, new_value}.
 
 -spec init() -> ok.
 init() ->
-    ok = amoc_metrics:init(counters, dummy_scenario_metric),
-    ok = amoc_metrics:init(times, dummy_scenario_metric),
+    true = amoc_metrics:init(counters, dummy_scenario_metric),
+    true = amoc_metrics:init(times, dummy_scenario_metric),
     %% amoc follows a couple of rules during the scenario initialisation:
     %%  - if any parameter verification fails, amoc will not start
     %%    the scenario and the init/0 function is not triggered.

--- a/src/amoc_metrics.erl
+++ b/src/amoc_metrics.erl
@@ -23,15 +23,15 @@ start() ->
     maybe_init_predefined_metrics(),
     maybe_add_exporter().
 
--spec init(type(), name()) -> ok.
+-spec init(type(), name()) -> boolean().
 init(counters, Name) ->
-    prometheus_counter:new([{name, Name}, {help, ""}]);
+    prometheus_counter:declare([{name, Name}, {help, ""}]);
 init(gauge, Name) ->
-    prometheus_gauge:new([{name, Name}, {help, ""}]);
+    prometheus_gauge:declare([{name, Name}, {help, ""}]);
 init(summary, Name) ->
-    prometheus_summary:new([{name, Name}, {help, ""}]);
+    prometheus_summary:declare([{name, Name}, {help, ""}]);
 init(Type, Name) when histogram =:= Type; times =:= Type ->
-    prometheus_histogram:new([{name, Name}, {buckets, histogram_buckets()}, {help, ""}]).
+    prometheus_histogram:declare([{name, Name}, {buckets, histogram_buckets()}, {help, ""}]).
 
 -spec update_counter(name()) -> ok.
 update_counter(Name) ->


### PR DESCRIPTION
It has been noted that this can fail to start again if the metric already existed. Exometer didn't use to fail, but now prometheus would.